### PR TITLE
Remove deprecated, non nested error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _None_
 * The `ParametersError` enum has been replaced by the `Parameters.Error` nested type.  
   [Olivier Halligon](https://github.com/AliGator)
   [#?](https://github.com/SwiftGen/SwiftGenKit/pulls/#)
+* The `FilterError` enum has been replaced by the `Filters.Error` nested type.  
+  [Olivier Halligon](https://github.com/AliGator)
+  [#?](https://github.com/SwiftGen/SwiftGenKit/pulls/#)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### Breaking Changes
 
-_None_
+* The `ParametersError` enum has been replaced by the `Parameters.Error` nested type.  
+  [Olivier Halligon](https://github.com/AliGator)
+  [#?](https://github.com/SwiftGen/SwiftGenKit/pulls/#)
 
 ### New Features
 

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -7,10 +7,6 @@
 import Foundation
 import Stencil
 
-// For retro-compatibility. Remove in next major.
-@available(*, deprecated, renamed: "Filters.Error", message: "Use the Filters.Error nested type instead")
-typealias FilterError = Filters.Error
-
 enum Filters {
   enum Error: Swift.Error {
     case invalidInputType

--- a/Sources/Parameters.swift
+++ b/Sources/Parameters.swift
@@ -6,10 +6,6 @@
 
 import Foundation
 
-// For retro-compatibility. Remove in next major.
-@available(*, deprecated, renamed: "Parameters.Error", message: "Use the Parameters.Error nested type instead")
-public typealias ParametersError = Parameters.Error
-
 /// Namespace to handle extra context parameters passed as a list of `foo=bar` strings.
 /// Typically used when parsing command-line arguments one by one
 /// (like `foo=bar pt.x=1 pt.y=2 values=1 values=2 values=3 flag`)


### PR DESCRIPTION
This PR sits on top of #36 and is breaking.
It can be considered one small part of #5

It should only be merged once #36 has been merged then released as a new version on CP. Then we could rebase it on top of the new master after release and merge it once we're ready for the next major version to removed the depreciations.

Note that we'll probably have a conflict on the CHANGELOG when rebasing and during that conflict we should make sure to move the entries to the (future) proper section associated with the right version and not to keep them at their current location.

TODO:
 - [x] Rebase on master
 - [x] Check that changelog entry is in correct position after merge.