### PR TITLE
Remove `StringFilters` and `NumFilters` typealiases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ _None_
 * The `FilterError` enum has been replaced by the `Filters.Error` nested type.  
   [Olivier Halligon](https://github.com/AliGator)
   [#37](https://github.com/SwiftGen/SwiftGenKit/pulls/37)
+* The filters in `StringFilters` and `NumFilters` are now located under `Filters.Strings` and `Filters.Numbers`.  
+  [Olivier Halligon](https://github.com/AliGator)
+  [#40](https://github.com/SwiftGen/SwiftGenKit/pulls/40)
 * Removed the `join` filter, as it's now integrated in `Stencil` proper.  
   [David Jennes](https://github.com/djbe)
   [#10](https://github.com/SwiftGen/StencilSwiftKit/pull/10)

--- a/Sources/Filters+Numbers.swift
+++ b/Sources/Filters+Numbers.swift
@@ -7,10 +7,6 @@
 import Foundation
 import Stencil
 
-// For retro-compatibility. Remove in next major.
-@available(*, deprecated, renamed: "Filters.Numbers", message: "Use the Filters.Numbers nested type instead")
-typealias NumFilters = Filters.Numbers
-
 extension Filters {
   enum Numbers {
     static func hexToInt(_ value: Any?) throws -> Any? {

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -7,10 +7,6 @@
 import Foundation
 import Stencil
 
-// For retro-compatibility. Remove in next major.
-@available(*, deprecated, renamed: "Filters.Strings", message: "Use the Filters.Strings nested type instead")
-typealias StringFilters = Filters.Strings
-
 extension Filters {
   enum Strings {
     fileprivate static let reservedKeywords = [


### PR DESCRIPTION
Use `Filters.Strings` and `Filters.Numbers` instead.