### PR TITLE
Fix snakeToCamelCase readme documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Bug Fixes
 
-_None_
+* Fix `snakeToCamelCase` parameters information in README.  
+  [Liquidsoul](https://github.com/Liquidsoul)
+  [#45](https://github.com/SwiftGen/StencilSwiftKit/pulls/45)
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 * [String filters](Documentation/filters-strings.md):
   * `escapeReservedKeywords`: Escape keywods reserved in the Swift language, by wrapping them inside backticks so that the can be used as regular escape keywords in Swift code.
   * `lowerFirstWord`
-  * `snakeToCamelCase`: Transforms text from snake_case to camelCase. By default it keeps leading underscores, unless a single optional argument is set to "true", "no" or "0".
+  * `snakeToCamelCase`: Transforms text from snake_case to camelCase. By default it keeps leading underscores, unless a single optional argument is set to "true", "yes" or "1".
   * `camelToSnakeCase`: Transforms text from camelCase to snake_case. By default it converts to lower case, unless a single optional argument is set to "false", "no" or "0".
   * `swiftIdentifier`: Transforms an arbitrary string into a valid Swift identifier (using only valid characters for a Swift identifier as defined in the Swift language reference)
   * `titlecase`


### PR DESCRIPTION
I've noticed that the information about `snakeToCamelCase`'s parameter in the README is wrong so this PR fixes this.
I've also added some tests to show that and ensure that I was not mistaking 😅 