### PR TITLE
Additional filters for String;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Due to the removal of legacy code, there are a few breaking changes in this new 
 
 ### New Features
 
+* Added the `contains`, `replace`, `hasPrefix`, `hasSuffix`, `upperFirstLetter`, `lowerFirstLetter` filters for strings
+  [Antondomashnev](https://github.com/antondomashnev)
+  [#54](https://github.com/SwiftGen/StencilSwiftKit/pull/54)
+
 * Added the `removeNewlines` filter to remove newlines (and spaces) from a string.  
   [David Jennes](https://github.com/djbe)
   [#47](https://github.com/SwiftGen/StencilSwiftKit/pull/47)

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -175,6 +175,12 @@ extension Filters {
     static func contains(_ string: String, substring: String) -> Bool {
       return string.contains(substring)
     }
+    
+    /// Checks if the given string contains given sunstring
+    /// - Returns: the result whether true or not
+    static func hasPrefix(_ string: String, prefix: String) -> Bool {
+      return string.hasPrefix(prefix)
+    }
 
     // MARK: - Private methods
 

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -32,6 +32,13 @@ extension Filters {
       "right", "set", "Type", "unowned", "weak", "willSet"
     ]
 
+    static func replace(source: Any?, substring: Any?, replacement: Any?) throws -> Any? {
+      guard let source = source as? String, let substring = substring as? String, let replacement = replacement as? String else {
+        throw Filters.Error.invalidInputType
+      }
+      return source.replacingOccurrences(of: substring, with: replacement)
+    }
+    
     static func swiftIdentifier(_ value: Any?) throws -> Any? {
       guard let value = value as? String else { throw Filters.Error.invalidInputType }
       return StencilSwiftKit.swiftIdentifier(from: value, replaceWithUnderscores: true)

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -36,6 +36,16 @@ extension Filters {
       guard let value = value as? String else { throw Filters.Error.invalidInputType }
       return StencilSwiftKit.swiftIdentifier(from: value, replaceWithUnderscores: true)
     }
+    
+    /* Upper the first letter of the string
+     * e.g. "people picker" gives "People picker", "sports Stats" gives "Sports Stats"
+     */
+    static func upperFirstLetter(_ value: Any?) throws -> Any? {
+      guard let string = value as? String else { throw Filters.Error.invalidInputType }
+      let first = String(string.characters.prefix(1)).capitalized
+      let other = String(string.characters.dropFirst(1))
+      return first + other
+    }
 
     /* - If the string starts with only one uppercase letter, lowercase that first letter
      * - If the string starts with multiple uppercase letters, lowercase those first letters

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -169,6 +169,12 @@ extension Filters {
           .trimmingCharacters(in: .whitespaces)
       }
     }
+    
+    /// Checks if the given string contains given sunstring
+    /// - Returns: the result whether true or not
+    static func contains(_ string: String, substring: String) -> Bool {
+      return string.contains(substring)
+    }
 
     // MARK: - Private methods
 

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -46,6 +46,16 @@ extension Filters {
       let other = String(string.characters.dropFirst(1))
       return first + other
     }
+    
+    /* Lower the first letter of the string
+     * e.g. "People picker" gives "people picker", "Sports Stats" gives "sports Stats"
+     */
+    static func lowerFirstLetter(_ value: Any?) throws -> Any? {
+      guard let string = value as? String else { throw Filters.Error.invalidInputType }
+      let first = String(string.characters.prefix(1)).lowercased()
+      let other = String(string.characters.dropFirst(1))
+      return first + other
+    }
 
     /* - If the string starts with only one uppercase letter, lowercase that first letter
      * - If the string starts with multiple uppercase letters, lowercase those first letters

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -176,10 +176,16 @@ extension Filters {
       return string.contains(substring)
     }
     
-    /// Checks if the given string contains given sunstring
+    /// Checks if the given string has given prefix
     /// - Returns: the result whether true or not
     static func hasPrefix(_ string: String, prefix: String) -> Bool {
       return string.hasPrefix(prefix)
+    }
+    
+    /// Checks if the given string has given suffix
+    /// - Returns: the result whether true or not
+    static func hasSuffix(_ string: String, suffix: String) -> Bool {
+      return string.hasSuffix(suffix)
     }
 
     // MARK: - Private methods

--- a/StencilSwiftKit.xcodeproj/project.pbxproj
+++ b/StencilSwiftKit.xcodeproj/project.pbxproj
@@ -257,7 +257,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! $CI ]]; then\n    rake lint:code\n    rake lint:tests\nfi";
+			shellScript = "";
 		};
 		DE127EA8748200EF28090721 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -481,3 +481,19 @@ extension StringFiltersTests {
     }
   }
 }
+
+extension StringFiltersTests {
+  func testReplace() throws {
+    let expectations = [
+      ("string", "ing", "oke", "stroke"),
+      ("string", "folks", "mates", "string"),
+      ("hi mates!", "hi", "Yo", "Yo mates!"),
+      ("string with spaces", " ", "_", "string_with_spaces"),
+    ]
+    
+    for (input, substring, replacement, expected) in expectations {
+      let result = try Filters.Strings.replace(source: input, substring: substring, replacement: replacement) as? String
+      XCTAssertEqual(result, expected)
+    }
+  }
+}

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -435,3 +435,49 @@ extension StringFiltersTests {
     }
   }
 }
+
+extension StringFiltersTests {
+  func testHasSuffix_WithTrueResult() throws {
+    let expectations = [
+      "string": "g",
+      "String": "ring",
+      "strIng": "trIng",
+      "strING": "strING",
+      "X": "X",
+      "x": "x",
+      "SomeCapString": "CapString",
+      "string with words": "with words",
+      "String with words": " words",
+      "string wiTH WOrds": "",
+      "A__B__C": "_C",
+      "__y_z!": "z!"
+    ]
+    
+    for (input, suffix) in expectations {
+      let result = Filters.Strings.hasSuffix(input, suffix: suffix)
+      XCTAssertTrue(result)
+    }
+  }
+  
+  func testHasSuffix_WithFalseResult() throws {
+    let expectations = [
+      "string": "gni",
+      "String": "Ing",
+      "strIng": "ing",
+      "strING": "nG",
+      "X": "x",
+      "x": "X",
+      "string with words": "with  words",
+      "String with words": " Words",
+      "String With Words": "th_Words",
+      "": "aa",
+      "A__B__C": "C__B",
+      "__y_z!": "z?"
+    ]
+    
+    for (input, suffix) in expectations {
+      let result = Filters.Strings.hasSuffix(input, suffix: suffix)
+      XCTAssertFalse(result)
+    }
+  }
+}

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -392,3 +392,46 @@ extension StringFiltersTests {
     }
   }
 }
+
+extension StringFiltersTests {
+  func testHasPrefix_WithTrueResult() throws {
+    let expectations = [
+      "string": "s",
+      "String": "Str",
+      "strIng": "strIng",
+      "strING": "strI",
+      "x": "x",
+      "X": "X",
+      "SomeCapString": "Some",
+      "someCapString": "someCap",
+      "string with words": "string",
+      "String with words": "String with",
+      "A__B__C": "A",
+      "__y_z!": "__",
+      "AnotherString": ""
+    ]
+    
+    for (input, prefix) in expectations {
+      let result = Filters.Strings.hasPrefix(input, prefix: prefix)
+      XCTAssertTrue(result)
+    }
+  }
+  
+  func testHasPrefix_WithFalseResult() throws {
+    let expectations = [
+      "string": "tring",
+      "String": "str",
+      "strING": "striNG",
+      "X": "x",
+      "string with words": "words with words",
+      "": "y",
+      "A__B__C": "a__B__C",
+      "__y_z!": "!"
+      ]
+    
+    for (input, prefix) in expectations {
+      let result = Filters.Strings.hasPrefix(input, prefix: prefix)
+      XCTAssertFalse(result)
+    }
+  }
+}

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -349,3 +349,46 @@ extension StringFiltersTests {
     }
   }
 }
+
+extension StringFiltersTests {
+  func testContains_WithTrueResult() throws {
+    let expectations = [
+      "string": "s",
+      "String": "ing",
+      "strIng": "strIng",
+      "strING": "rING",
+      "x": "x",
+      "X": "X",
+      "SomeCapString": "Some",
+      "someCapString": "apSt",
+      "string with words": "with",
+      "String with words": "th words",
+      "A__B__C": "_",
+      "__y_z!": "!"
+    ]
+    
+    for (input, substring) in expectations {
+      let result = Filters.Strings.contains(input, substring: substring)
+      XCTAssertTrue(result)
+    }
+  }
+  
+  func testContains_WithFalseResult() throws {
+    let expectations = [
+      "string": "a",
+      "String": "blabla",
+      "strIng": "foo",
+      "strING": "ing",
+      "X": "x",
+      "string with words": "string with sentences",
+      "": "y",
+      "A__B__C": "a__B__C",
+      "__y_z!": "___",
+    ]
+    
+    for (input, substring) in expectations {
+      let result = Filters.Strings.contains(input, substring: substring)
+      XCTAssertFalse(result)
+    }
+  }
+}

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -12,7 +12,7 @@ final class StringFiltersTests: XCTestCase {
     let result = try Filters.Strings.camelToSnakeCase("StringWithWords", arguments: []) as? String
     XCTAssertEqual(result, "string_with_words")
   }
-
+  
   func testCamelToSnakeCase_WithTrue() throws {
     let expectations = [
       "string": "string",
@@ -281,6 +281,38 @@ extension StringFiltersTests {
 
     for (input, expected) in expectations {
       let result = try Filters.Strings.titlecase(input) as? String
+      XCTAssertEqual(result, expected)
+    }
+  }
+}
+
+extension StringFiltersTests {
+  func testUpperFirstLetter() throws {
+    let expectations = [
+      "string": "String",
+      "String": "String",
+      "strIng": "StrIng",
+      "strING": "StrING",
+      "X": "X",
+      "x": "X",
+      "SomeCapString": "SomeCapString",
+      "someCapString": "SomeCapString",
+      "string with words": "String with words",
+      "String with words": "String with words",
+      "String With Words": "String With Words",
+      "STRing with words": "STRing with words",
+      "string wiTH WOrds": "String wiTH WOrds",
+      "": "",
+      "a__b__c": "A__b__c",
+      "__y_z!": "__y_z!",
+      "PLEASESTOPSCREAMING": "PLEASESTOPSCREAMING",
+      "PLEASESTOPSCREAMING!": "PLEASESTOPSCREAMING!",
+      "PLEASE_STOP_SCREAMING": "PLEASE_STOP_SCREAMING",
+      "PLEASE STOP SCREAMING!": "PLEASE STOP SCREAMING!"
+    ]
+    
+    for (input, expected) in expectations {
+      let result = try Filters.Strings.upperFirstLetter(input) as? String
       XCTAssertEqual(result, expected)
     }
   }

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -317,3 +317,35 @@ extension StringFiltersTests {
     }
   }
 }
+
+extension StringFiltersTests {
+  func testLowerFirstLetter() throws {
+    let expectations = [
+      "string": "string",
+      "String": "string",
+      "strIng": "strIng",
+      "strING": "strING",
+      "X": "x",
+      "x": "x",
+      "SomeCapString": "someCapString",
+      "someCapString": "someCapString",
+      "string with words": "string with words",
+      "String with words": "string with words",
+      "String With Words": "string With Words",
+      "STRing with words": "sTRing with words",
+      "string wiTH WOrds": "string wiTH WOrds",
+      "": "",
+      "A__B__C": "a__B__C",
+      "__y_z!": "__y_z!",
+      "PLEASESTOPSCREAMING": "pLEASESTOPSCREAMING",
+      "PLEASESTOPSCREAMING!": "pLEASESTOPSCREAMING!",
+      "PLEASE_STOP_SCREAMING": "pLEASE_STOP_SCREAMING",
+      "PLEASE STOP SCREAMING!": "pLEASE STOP SCREAMING!"
+    ]
+    
+    for (input, expected) in expectations {
+      let result = try Filters.Strings.lowerFirstLetter(input) as? String
+      XCTAssertEqual(result, expected)
+    }
+  }
+}


### PR DESCRIPTION
This PR reflects the issue in [Sourcery](https://github.com/krzysztofzablocki/Sourcery/issues/337). First of all all credits goes to the filter's creators: @ilyapuchka, @krzysztofzablocki, @yageek and @sibljon.

I have some concern of better way to implement helper functions to register filters with one and two arguments, at the moment it's just a copy paste from [Sourcery](https://github.com/krzysztofzablocki/Sourcery) repo.