### PR TITLE
Add Context.enrich variant taking a dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ _None_
 * Accept `LosslessStringConvertible` input for strings filters.  
   [Antondomashnev](https://github.com/antondomashnev)
   [#65](https://github.com/SwiftGen/StencilSwiftKit/pull/65)
+* `StencilContext.enrich` now also accept a Dictionary for specifying parameters
+  (in preparation for supporting Config files in SwiftGen).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#66](https://github.com/SwiftGen/StencilSwiftKit/pull/66)
 
 ### Internal Changes
 

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -23,7 +23,7 @@ public enum StencilContext {
   public static func enrich(context: [String: Any],
                             parameters: [String],
                             environment: [String: String] =
-    ProcessInfo.processInfo.environment) throws -> [String: Any] {
+                            ProcessInfo.processInfo.environment) throws -> [String: Any] {
     let params = try Parameters.parse(items: parameters)
     return try enrich(context: context, parameters: params, environment: environment)
   }

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -15,7 +15,7 @@ public enum StencilContext {
   /// Enriches a stencil context with parsed parameters and environment variables
   ///
   /// - Parameters:
-  ///   - context: The stencil context
+  ///   - context: The stencil context to enrich
   ///   - parameters: List of strings, will be parsed using the `Parameters.parse(items:)` method
   ///   - environment: Environment variables, defaults to `ProcessInfo().environment`
   /// - Returns: The new Stencil context enriched with the parameters and env variables
@@ -23,11 +23,27 @@ public enum StencilContext {
   public static func enrich(context: [String: Any],
                             parameters: [String],
                             environment: [String: String] =
+    ProcessInfo.processInfo.environment) throws -> [String: Any] {
+    let params = try Parameters.parse(items: parameters)
+    return try enrich(context: context, parameters: params, environment: environment)
+  }
+
+  /// Enriches a stencil context with parsed parameters and environment variables
+  ///
+  /// - Parameters:
+  ///   - context: The stencil context to enrich
+  ///   - parameters: Dictionary of parameters. Can be structured in sub-dictionaries.
+  ///   - environment: Environment variables, defaults to `ProcessInfo().environment`
+  /// - Returns: The new Stencil context enriched with the parameters and env variables
+  /// - Throws: `Parameters.Error`
+  public static func enrich(context: [String: Any],
+                            parameters: [String: Any],
+                            environment: [String: String] =
                             ProcessInfo.processInfo.environment) throws -> [String: Any] {
     var context = context
 
     context[environmentKey] = merge(context[environmentKey], with: environment)
-    context[parametersKey] = merge(context[parametersKey], with: try Parameters.parse(items: parameters))
+    context[parametersKey] = merge(context[parametersKey], with: parameters)
 
     return context
   }


### PR DESCRIPTION
In preparation for supporting config files in SwiftGen

(See [the feature/swiftgen-yml branch](https://github.com/SwiftGen/SwiftGen/compare/feature/swiftgen-yml) especially [those lines](https://github.com/SwiftGen/SwiftGen/blob/3760585271a75d4a33aa43d52cceeba9145839ad/Sources/ConfigCommands.swift#L28-L31) which would need that function to work properly)