### PR TITLE
Workaround for parseString to support NSString;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ---
 
+## Master
+
+### Bug Fixes
+
+* Workaround for `parseString` to support `NSString`.
+  [Antondomashnev](https://github.com/antondomashnev)
+  [#68](https://github.com/SwiftGen/StencilSwiftKit/pull/68)
+
+### Breaking Changes
+
+_None_
+
+### New Features
+
+_None_
+
+### Internal Changes
+
+_None_
+
+
 ## 2.2.0
 
 ### New Features

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -20,10 +20,13 @@ enum Filters {
   ///   - value: an input value, may be nil
   /// - Throws: Filters.Error.invalidInputType
   static func parseString(from value: Any?) throws -> String {
-    guard let stringArg = value as? LosslessStringConvertible else {
-      throw Error.invalidInputType
+    if let losslessString = value as? LosslessStringConvertible {
+        return String(describing: losslessString)
     }
-    return String(describing: stringArg)
+    if let string = value as? String {
+        return string
+    }
+    throw Error.invalidInputType
   }
 
   /// Parses filter arguments for a string value, where accepted objects must conform to 
@@ -34,10 +37,16 @@ enum Filters {
   ///   - index: the index in the arguments array
   /// - Throws: Filters.Error.invalidInputType
   static func parseStringArgument(from arguments: [Any?], at index: Int = 0) throws -> String {
-    guard index < arguments.count, let stringArg = arguments[index] as? LosslessStringConvertible else {
-      throw Error.invalidInputType
+    guard index < arguments.count else {
+        throw Error.invalidInputType
     }
-    return String(describing: stringArg)
+    if let losslessString = arguments[index] as? LosslessStringConvertible {
+        return String(describing: losslessString)
+    }
+    if let string = arguments[index] as? String {
+        return string
+    }
+    throw Error.invalidInputType
   }
 
   /// Parses filter arguments for a boolean value, where true can by any one of: "true", "yes", "1", and

--- a/Tests/StencilSwiftKitTests/ParseStringTests.swift
+++ b/Tests/StencilSwiftKitTests/ParseStringTests.swift
@@ -33,7 +33,7 @@ class ParseStringTests: XCTestCase {
     let value = try Filters.parseString(from: NSString(string: "foo"))
     XCTAssertEqual(value, "foo")
   }
-  
+
   func testParseString_FromValue_WithStringValue() throws {
     let value = try Filters.parseString(from: "foo")
     XCTAssertEqual(value, "foo")

--- a/Tests/StencilSwiftKitTests/ParseStringTests.swift
+++ b/Tests/StencilSwiftKitTests/ParseStringTests.swift
@@ -29,6 +29,11 @@ class ParseStringTests: XCTestCase {
 
   struct TestNotConvertible {}
 
+  func testParseString_FromValue_WithNSStringValue() throws {
+    let value = try Filters.parseString(from: NSString(string: "foo"))
+    XCTAssertEqual(value, "foo")
+  }
+  
   func testParseString_FromValue_WithStringValue() throws {
     let value = try Filters.parseString(from: "foo")
     XCTAssertEqual(value, "foo")


### PR DESCRIPTION
Apparently `NSString` is not bridged to `LosslessStringConvertible` although it's bridged to `String` and `String` conforms to `LosslessStringConvertible` 😞 

FYI there is an open [ticket](https://bugs.swift.org/browse/SR-6050) for Swift to track the progress. 