### PR TITLE
Adds Parameters.flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ _None_
 
 ### New Features
 
-_None_
+* Added `Parameters.flatten(dictionary:)` method to do the opposite of
+  `Parameters.parse(items:)` and turn a dictionary into the list of parameters to pass from the command line.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#70](https://github.com/SwiftGen/StencilSwiftKit/pull/70)
 
 ### Internal Changes
 

--- a/Sources/Filters+Numbers.swift
+++ b/Sources/Filters+Numbers.swift
@@ -11,7 +11,7 @@ extension Filters {
   enum Numbers {
     static func hexToInt(_ value: Any?) throws -> Any? {
       guard let value = value as? String else { throw Filters.Error.invalidInputType }
-      return Int(value, radix:  16)
+      return Int(value, radix: 16)
     }
 
     static func int255toFloat(_ value: Any?) throws -> Any? {

--- a/Tests/StencilSwiftKitTests/ContextTests.swift
+++ b/Tests/StencilSwiftKitTests/ContextTests.swift
@@ -32,7 +32,7 @@ class ContextTests: XCTestCase {
   }
 
   func testWithContext() throws {
-    let context: [String : Any] = ["foo": "bar", "hello": true]
+    let context: [String: Any] = ["foo": "bar", "hello": true]
 
     let result = try StencilContext.enrich(context: context,
                                            parameters: [],

--- a/Tests/StencilSwiftKitTests/ParametersTests.swift
+++ b/Tests/StencilSwiftKitTests/ParametersTests.swift
@@ -17,6 +17,13 @@ class ParametersTests: XCTestCase {
     XCTAssertEqual(result["b"] as? String, "hello")
     XCTAssertEqual(result["c"] as? String, "x=y")
     XCTAssertEqual(result["d"] as? Bool, true)
+
+    // Test the opposite operation (flatten) as well
+    let reverse = Parameters.flatten(dictionary: result)
+    XCTAssertEqual(reverse.count, items.count,
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
+    XCTAssertEqual(Set(reverse), Set(items),
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
   func testStructured() throws {
@@ -28,6 +35,13 @@ class ParametersTests: XCTestCase {
     XCTAssertEqual(sub["baz"] as? String, "1")
     XCTAssertEqual(sub["bar"] as? String, "2")
     XCTAssertEqual(sub["test"] as? Bool, true)
+
+    // Test the opposite operation (flatten) as well
+    let reverse = Parameters.flatten(dictionary: result)
+    XCTAssertEqual(reverse.count, items.count,
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
+    XCTAssertEqual(Set(reverse), Set(items),
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
   func testDeepStructured() throws {
@@ -40,6 +54,13 @@ class ParametersTests: XCTestCase {
     guard let baz = bar["baz"] as? [String: Any] else { XCTFail("Parsed parameter should be a dictionary"); return }
     guard let qux = baz["qux"] as? String else { XCTFail("Parsed parameter should be a string"); return }
     XCTAssertEqual(qux, "1")
+
+    // Test the opposite operation (flatten) as well
+    let reverse = Parameters.flatten(dictionary: result)
+    XCTAssertEqual(reverse.count, items.count,
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
+    XCTAssertEqual(Set(reverse), Set(items),
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
   func testRepeated() throws {
@@ -52,9 +73,16 @@ class ParametersTests: XCTestCase {
     XCTAssertEqual(sub[0], "1")
     XCTAssertEqual(sub[1], "2")
     XCTAssertEqual(sub[2], "hello")
+
+    // Test the opposite operation (flatten) as well
+    let reverse = Parameters.flatten(dictionary: result)
+    XCTAssertEqual(reverse.count, items.count,
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
+    XCTAssertEqual(Set(reverse), Set(items),
+                   "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
-  func testInvalidSyntax() {
+  func testParseInvalidSyntax() {
     // invalid character
     do {
       let items = ["foo:1"]
@@ -89,7 +117,7 @@ class ParametersTests: XCTestCase {
     }
   }
 
-  func testInvalidKey() {
+  func testParseInvalidKey() {
     // key may only be alphanumeric or '.'
     do {
       let items = ["foo:bar=1"]
@@ -124,7 +152,7 @@ class ParametersTests: XCTestCase {
     }
   }
 
-  func testInvalidStructure() {
+  func testParseInvalidStructure() {
     // can't switch from string to dictionary
     do {
       let items = ["foo=1", "foo.bar=1"]

--- a/Tests/StencilSwiftKitTests/ParametersTests.swift
+++ b/Tests/StencilSwiftKitTests/ParametersTests.swift
@@ -80,6 +80,8 @@ class ParametersTests: XCTestCase {
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
     XCTAssertEqual(Set(reverse), Set(items),
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
+    XCTAssertEqual(reverse, items,
+                   "The order of arrays are properly preserved when flattened")
   }
 
   func testParseInvalidSyntax() {


### PR DESCRIPTION
This method is the opposite action of `Parameters.parse`.

Its main goal is essentially to give back a description on how you pass parameters from the command line. Especially it will be used for verbose mode when using a `swiftgen.yml` config file, to print CLI calls being done.

This PR is needed for https://github.com/SwiftGen/SwiftGen/pull/337 to be merged.