### PR TITLE
Enable extra SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,3 @@
-disabled_rules:
- - type_name
-
 opt_in_rules:
  - array_init
  - attributes

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,7 +2,35 @@ disabled_rules:
  - type_name
 
 opt_in_rules:
+ - array_init
+ - attributes
+ - closure_end_indentation
+ - closure_spacing
+ - contains_over_first_not_nil
+ - discouraged_optional_boolean
+ - empty_count
+ - fatal_error_message
+ - first_where
  - force_unwrapping
+ - implicit_return
+ - implicitly_unwrapped_optional
+ - joined_default_parameter
+ - literal_expression_end_indentation
+ - multiline_arguments
+ - multiline_parameters
+ - operator_usage_whitespace
+ - overridden_super_call
+ - override_in_extension
+ - private_action
+ - private_outlet
+ - prohibited_super_call
+ - redundant_nil_coalescing
+ - sorted_first_last
+ - sorted_imports
+ - trailing_closure
+ - unneeded_parentheses_in_closure_argument
+ - vertical_parameter_alignment_on_call
+ - yoda_condition
 
 # Rules customization
 line_length:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ _None_
 * Switched to using SwiftLint via CocoaPods instead of our own install scripts.  
   [David Jennes](https://github.com/djbe) 
   [#78](https://github.com/SwiftGen/StencilSwiftKit/pull/78)
+* Enabled some extra SwiftLint rules for better code consistency.  
+  [David Jennes](https://github.com/djbe) 
+  [#79](https://github.com/SwiftGen/StencilSwiftKit/pull/79)
 
 ## 2.4.0
 

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -18,7 +18,10 @@ public extension Extension {
   private func registerFilter(_ name: String, filter: @escaping Filters.BooleanWithArguments) {
     typealias GenericFilter = (Any?, [Any?]) throws -> Any?
     registerFilter(name, filter: filter as GenericFilter)
-    registerFilter("!\(name)", filter: { value, arguments in try !filter(value, arguments)} as GenericFilter)
+    // swiftlint:disable:next trailing_closure
+    registerFilter("!\(name)", filter: { value, arguments in
+      try !filter(value, arguments)
+    } as GenericFilter)
   }
 
   private func registerNumbersFilters() {

--- a/Sources/Filters+Strings.swift
+++ b/Sources/Filters+Strings.swift
@@ -159,10 +159,10 @@ extension Filters.Strings {
     let unprefixed: String
     if try containsAnyLowercasedChar(string) {
       let comps = string.components(separatedBy: "_")
-      unprefixed = comps.map { upperFirstLetter($0) }.joined(separator: "")
+      unprefixed = comps.map { upperFirstLetter($0) }.joined()
     } else {
       let comps = try snakecase(string).components(separatedBy: "_")
-      unprefixed = comps.map { $0.capitalized }.joined(separator: "")
+      unprefixed = comps.map { $0.capitalized }.joined()
     }
 
     // only if passed true, strip the prefix underscores

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -61,6 +61,7 @@ enum Filters {
   ///   - required: If true, the argument is required and function throws if missing.
   ///               If false, returns nil on missing args.
   /// - Throws: Filters.Error.invalidInputType
+  // swiftlint:disable discouraged_optional_boolean
   static func parseBool(from arguments: [Any?], at index: Int = 0, required: Bool = true) throws -> Bool? {
     guard index < arguments.count, let boolArg = arguments[index] as? String else {
       if required {
@@ -79,6 +80,7 @@ enum Filters {
       throw Error.invalidInputType
     }
   }
+  // swiftlint:enable discouraged_optional_boolean
 
   /// Parses filter arguments for an enum value (with a String rawvalue).
   ///

--- a/Sources/MapNode.swift
+++ b/Sources/MapNode.swift
@@ -53,8 +53,8 @@ class MapNode: NodeType {
   func render(_ context: Context) throws -> String {
     let values = try variable.resolve(context)
 
-    if let values = values as? [Any], values.count > 0 {
-      let mappedValues: [String] = try values.enumerated().map { (index, item) in
+    if let values = values as? [Any], !values.isEmpty {
+      let mappedValues: [String] = try values.enumerated().map { index, item in
         let mapContext = self.context(values: values, index: index, item: item)
 
         return try context.push(dictionary: mapContext) {

--- a/Sources/SwiftIdentifier.swift
+++ b/Sources/SwiftIdentifier.swift
@@ -33,7 +33,7 @@ private let tailRanges: [CountableClosedRange<Int>] = [
 ]
 
 private func identifierCharacterSets(exceptions: String) -> (head: NSMutableCharacterSet, tail: NSMutableCharacterSet) {
-  let addRange: (NSMutableCharacterSet, CountableClosedRange<Int>) -> Void = { (mcs, range) in
+  let addRange: (NSMutableCharacterSet, CountableClosedRange<Int>) -> Void = { mcs, range in
     mcs.addCharacters(in: NSRange(location: range.lowerBound, length: range.count))
   }
 
@@ -63,7 +63,7 @@ enum SwiftIdentifier {
 
     let parts = string.components(separatedBy: tail.inverted)
     let replacement = underscores ? "_" : ""
-    let mappedParts = parts.map({ (string: String) -> String in
+    let mappedParts = parts.map { (string: String) -> String in
       // Can't use capitalizedString here because it will lowercase all letters after the first
       // e.g. "SomeNiceIdentifier".capitalizedString will because "Someniceidentifier" which is not what we want
       let ns = NSString(string: string)
@@ -74,7 +74,7 @@ enum SwiftIdentifier {
       } else {
         return ""
       }
-    })
+    }
 
     let result = mappedParts.joined(separator: replacement)
     return prefixWithUnderscoreIfNeeded(string: result, forbiddenChars: exceptions)

--- a/Tests/StencilSwiftKitTests/CallNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/CallNodeTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import Stencil
 @testable import StencilSwiftKit
+import XCTest
 
 class CallNodeTests: XCTestCase {
   func testParser() {

--- a/Tests/StencilSwiftKitTests/ContextTests.swift
+++ b/Tests/StencilSwiftKitTests/ContextTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 AliSoftware. All rights reserved.
 //
 
-import XCTest
 import StencilSwiftKit
+import XCTest
 
 class ContextTests: XCTestCase {
   func testEmpty() throws {

--- a/Tests/StencilSwiftKitTests/MacroNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/MacroNodeTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import Stencil
 @testable import StencilSwiftKit
+import XCTest
 
 class MacroNodeTests: XCTestCase {
   func testParser() {

--- a/Tests/StencilSwiftKitTests/MapNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/MapNodeTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import Stencil
 @testable import StencilSwiftKit
+import XCTest
 
 class MapNodeTests: XCTestCase {
   static let context = [

--- a/Tests/StencilSwiftKitTests/ParametersTests.swift
+++ b/Tests/StencilSwiftKitTests/ParametersTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import StencilSwiftKit
+import XCTest
 
 class ParametersTests: XCTestCase {
   func testBasic() throws {
@@ -20,9 +20,11 @@ class ParametersTests: XCTestCase {
 
     // Test the opposite operation (flatten) as well
     let reverse = Parameters.flatten(dictionary: result)
-    XCTAssertEqual(reverse.count, items.count,
+    XCTAssertEqual(reverse.count,
+                   items.count,
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
-    XCTAssertEqual(Set(reverse), Set(items),
+    XCTAssertEqual(Set(reverse),
+                   Set(items),
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
@@ -38,9 +40,11 @@ class ParametersTests: XCTestCase {
 
     // Test the opposite operation (flatten) as well
     let reverse = Parameters.flatten(dictionary: result)
-    XCTAssertEqual(reverse.count, items.count,
+    XCTAssertEqual(reverse.count,
+                   items.count,
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
-    XCTAssertEqual(Set(reverse), Set(items),
+    XCTAssertEqual(Set(reverse),
+                   Set(items),
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
@@ -57,9 +61,11 @@ class ParametersTests: XCTestCase {
 
     // Test the opposite operation (flatten) as well
     let reverse = Parameters.flatten(dictionary: result)
-    XCTAssertEqual(reverse.count, items.count,
+    XCTAssertEqual(reverse.count,
+                   items.count,
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
-    XCTAssertEqual(Set(reverse), Set(items),
+    XCTAssertEqual(Set(reverse),
+                   Set(items),
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
   }
 
@@ -76,11 +82,14 @@ class ParametersTests: XCTestCase {
 
     // Test the opposite operation (flatten) as well
     let reverse = Parameters.flatten(dictionary: result)
-    XCTAssertEqual(reverse.count, items.count,
+    XCTAssertEqual(reverse.count,
+                   items.count,
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
-    XCTAssertEqual(Set(reverse), Set(items),
+    XCTAssertEqual(Set(reverse),
+                   Set(items),
                    "Flattening the resulting dictionary back did not result in the equivalent of the original list")
-    XCTAssertEqual(reverse, items,
+    XCTAssertEqual(reverse,
+                   items,
                    "The order of arrays are properly preserved when flattened")
   }
 

--- a/Tests/StencilSwiftKitTests/ParseBoolTests.swift
+++ b/Tests/StencilSwiftKitTests/ParseBoolTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import StencilSwiftKit
+import XCTest
 
 class ParseBoolTests: XCTestCase {
   func testParseBool_TrueWithString() throws {

--- a/Tests/StencilSwiftKitTests/ParseEnumTests.swift
+++ b/Tests/StencilSwiftKitTests/ParseEnumTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import StencilSwiftKit
+import XCTest
 
 class ParseEnumTests: XCTestCase {
   enum Test: String {

--- a/Tests/StencilSwiftKitTests/ParseStringTests.swift
+++ b/Tests/StencilSwiftKitTests/ParseStringTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import StencilSwiftKit
+import XCTest
 
 class ParseStringTests: XCTestCase {
   struct TestLosslessConvertible: LosslessStringConvertible {

--- a/Tests/StencilSwiftKitTests/SetNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/SetNodeTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import Stencil
 @testable import StencilSwiftKit
+import XCTest
 
 class SetNodeTests: XCTestCase {
   func testParser() {

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -6,8 +6,8 @@
 
 // swiftlint:disable file_length
 
-import XCTest
 @testable import StencilSwiftKit
+import XCTest
 
 final class StringFiltersTests: XCTestCase {
   struct Input: LosslessStringConvertible, Hashable {
@@ -421,7 +421,7 @@ extension StringFiltersTests {
       Input(string: ""): "y",
       Input(string: "A__B__C"): "a__B__C",
       Input(string: "__y_z!"): "!"
-      ]
+    ]
 
     for (input, prefix) in expectations {
       let result = try Filters.Strings.hasPrefix(input, arguments: [prefix])

--- a/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
+++ b/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 @testable import StencilSwiftKit
+import XCTest
 
 class SwiftIdentifierTests: XCTestCase {
   func testBasicString() {

--- a/Tests/StencilSwiftKitTests/TestsHelper.swift
+++ b/Tests/StencilSwiftKitTests/TestsHelper.swift
@@ -5,8 +5,8 @@
 //
 
 import Foundation
-import XCTest
 import PathKit
+import XCTest
 
 private let colorCode: (String) -> String =
   ProcessInfo.processInfo.environment["XcodeColors"] == "YES" ? { "\u{001b}[\($0);" } : { _ in "" }
@@ -29,14 +29,14 @@ func diff(_ result: String, _ expected: String) -> String? {
   }
   if let badLineIdx = firstDiff {
     let slice = { (lines: [String], context: Int) -> ArraySlice<String> in
-      let start = max(0, badLineIdx-context)
-      let end = min(badLineIdx+context, lines.count-1)
+      let start = max(0, badLineIdx - context)
+      let end = min(badLineIdx + context, lines.count - 1)
       return lines[start...end]
     }
     let addLineNumbers = { (slice: ArraySlice) -> [String] in
       slice.enumerated().map { (idx: Int, line: String) in
         let num = idx + slice.startIndex
-        let lineNum = "\(num+1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
+        let lineNum = "\(num + 1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
         let clr = num == badLineIdx ? koCode : okCode
         return "\(clr.num)\(lineNum)\(reset)\(clr.code)\(line)\(reset)"
       }


### PR DESCRIPTION
This enables a bunch of optional SwiftLint rules that ensures the codebase is a bit more consistent.
Same as SwiftGen/SwiftGen#402

Note: built on top of #78, wait until that is merged.