### PR TITLE
Advanced Set tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ _None_
 
 ### New Features
 
-_None_
+* The `set` tag can now directly accept an expression as value, see the
+  [documentation](https://github.com/SwiftGen/StencilSwiftKit/blob/master/Documentation/tag-set.md)
+  for an explanation on how this differs with the normal `set`/`endset`
+  pair.  
+  [David Jennes](https://github.com/djbe)
+  [#247](https://github.com/AliSoftware/SwiftGen/pull/247)
 
 ### Internal Changes
 

--- a/Documentation/tag-set.md
+++ b/Documentation/tag-set.md
@@ -7,7 +7,7 @@ This tag stores a value into a variable for later use.
 | Name      | Description                                                            |
 |-----------|------------------------------------------------------------------------|
 | Tag Name  | `set`                                                                  |
-| End Tag   | `endset`  or N/A (if you're creating an alias of an existing variable) |
+| End Tag   | `endset` or N/A (if you're creating an alias of an existing variable) |
 | Rendering | Immediately; no output                                                 |
 
 | Parameter  | Description                                 | 
@@ -18,7 +18,7 @@ This tag stores a value into a variable for later use.
 The parameters and tags of this node depend on which mode you want to use:
 
 - Use `{% set myVar %}...{% endset %}` to render and store everything between the start and end tag into the variable.
-- Use `{% set myVar someOtherVar.prop1.prop2 #}` to evaluate and store an expression's result into the variable.
+- Use `{% set myVar someOtherVar.prop1.prop2 %}` to evaluate and store an expression's result into the variable.
 
 _Example of render:_ `{% set myVar %}hello{% endset %}`
 

--- a/Documentation/tag-set.md
+++ b/Documentation/tag-set.md
@@ -4,23 +4,34 @@ This tag stores a value into a variable for later use.
 
 ## Node Information
 
-| Name      | Description                      |
-|-----------|----------------------------------|
-| Tag Name  | `set`                            |
-| End Tag   | `endset`                         |
-| Rendering | Immediately; no output           |
+| Name      | Description                                                            |
+|-----------|------------------------------------------------------------------------|
+| Tag Name  | `set`                                                                  |
+| End Tag   | `endset`  or N/A (if you're creating an alias of an existing variable) |
+| Rendering | Immediately; no output                                                 |
 
-| Parameter | Description                                 | 
-|-----------|---------------------------------------------|
-| Name      | The name of the variable you want to store. |
+| Parameter  | Description                                 | 
+|------------|---------------------------------------------|
+| Name       | The name of the variable you want to store. |
+| Expression | (Optional) The value to be stored.          |
 
-_Example:_ `{% set myVar %}hello{% endset %}`
+The parameters and tags of this node depend on which mode you want to use:
+
+- Use `{% set myVar %}...{% endset %}` to render and store everything between the start and end tag into the variable.
+- Use `{% set myVar someOtherVar.prop1.prop2 #}` to evaluate and store an expression's result into the variable.
+
+_Example of render:_ `{% set myVar %}hello{% endset %}`
+
+_Example of evaluate:_ `{% set myVar2 myVar|uppercase %}`
 
 ## When to use it
 
 Useful when you have a certain calculation you want to re-use in multiple places without repeating yourself. For example you can compute only once the result of multiple filters applied in sequence to a variable, store that result and reuse it later.
 
-The content between the the `set` and `endset` tags is rendered immediately using the available context, and stored on the stack into a variable with the provided name.
+This tag can be used in 2 ways:
+
+- **Render**: the content between the the `set` and `endset` tags is rendered immediately using the available context, and stored on the stack into a variable with the provided name.
+- **Evaluate**: the provided expression is evaluated and stored into a variable with the provided name. This is especially useful if you want to avoid the conversion of contents to a String value (which *render* mode always does).
 
 Keep in mind that the variable is scoped, meaning that if you set a variable while (for example) inside a for loop, the set variable will not exist outside the scope of that for loop.
 
@@ -28,6 +39,7 @@ Keep in mind that the variable is scoped, meaning that if you set a variable whi
 
 ```stencil
 // we start with 'x' and 'y' as empty variables
+// 'items' is an array of integers in the context: [1, 3, 7]
 
 // set value
 {% set x %}hello{% endset %} 
@@ -50,4 +62,22 @@ Keep in mind that the variable is scoped, meaning that if you set a variable whi
 
 {{ greetings }}, {{ greetings }}, {{ greetings }}!
 // HELLO World, HELLO World, HELLO World!
+
+// Difference between render and evaluate:
+
+{% set a %}{{items}}{% endset %}
+{% set b items %}
+// a = "[1, 3, 7]", b = [1, 3, 7]
+// a is contains a string (the description of 'items')
+// b contains an array, the same value as 'items'
+
+// This will print every character in the string "[1, 3, 7]"
+{% for item in a %}
+	item = {{item}}
+{% endfor %}
+
+// This will print every item of the array [1, 3, 7]
+{% for item in b %}
+	item = {{item}}
+{% endfor %}
 ```

--- a/Sources/SetNode.swift
+++ b/Sources/SetNode.swift
@@ -7,33 +7,54 @@
 import Stencil
 
 class SetNode: NodeType {
-  let variableName: String
-  let nodes: [NodeType]
-
-  class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-    let comps = token.components()
-    guard comps.count == 2 else {
-      throw TemplateSyntaxError("'set' tag takes one argument, the name of the variable to set")
-    }
-    let variable = comps[1]
-
-    let setNodes = try parser.parse(until(["endset"]))
-
-    guard parser.nextToken() != nil else {
-      throw TemplateSyntaxError("`endset` was not found.")
-    }
-
-    return SetNode(variableName: variable, nodes: setNodes)
+  enum Content {
+    case nodes([NodeType])
+    case value(Resolvable)
   }
 
-  init(variableName: String, nodes: [NodeType]) {
+  let variableName: String
+  let content: Content
+
+  class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
+    let components = token.components()
+    guard components.count <= 3 else {
+      throw TemplateSyntaxError("""
+        'set' tag takes at least one argument (the name of the variable to set) \
+        and optionally the value expression.
+        """)
+    }
+
+    let variable = components[1]
+    if components.count == 3 {
+      // we have a value expression, no nodes
+      let value = try parser.compileFilter(components[2])
+      return SetNode(variableName: variable, content: .value(value))
+    } else {
+      // no value expression, parse until an `endset` node
+      let setNodes = try parser.parse(until(["endset"]))
+
+      guard parser.nextToken() != nil else {
+        throw TemplateSyntaxError("`endset` was not found.")
+      }
+
+      return SetNode(variableName: variable, content: .nodes(setNodes))
+    }
+  }
+
+  init(variableName: String, content: Content) {
     self.variableName = variableName
-    self.nodes = nodes
+    self.content = content
   }
 
   func render(_ context: Context) throws -> String {
-    let result = try renderNodes(nodes, context)
-    context[variableName] = result
+    switch content {
+    case .nodes(let nodes):
+      let result = try renderNodes(nodes, context)
+      context[variableName] = result
+    case .value(let value):
+      context[variableName] = try value.resolve(context)
+    }
+
     return ""
   }
 }

--- a/Sources/SetNode.swift
+++ b/Sources/SetNode.swift
@@ -9,7 +9,7 @@ import Stencil
 class SetNode: NodeType {
   enum Content {
     case nodes([NodeType])
-    case value(Resolvable)
+    case reference(to: Resolvable)
   }
 
   let variableName: String
@@ -28,7 +28,7 @@ class SetNode: NodeType {
     if components.count == 3 {
       // we have a value expression, no nodes
       let value = try parser.compileFilter(components[2])
-      return SetNode(variableName: variable, content: .value(value))
+      return SetNode(variableName: variable, content: .reference(to: value))
     } else {
       // no value expression, parse until an `endset` node
       let setNodes = try parser.parse(until(["endset"]))
@@ -51,7 +51,7 @@ class SetNode: NodeType {
     case .nodes(let nodes):
       let result = try renderNodes(nodes, context)
       context[variableName] = result
-    case .value(let value):
+    case .reference(let value):
       context[variableName] = try value.resolve(context)
     }
 

--- a/Tests/StencilSwiftKitTests/SetNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/SetNodeTests.swift
@@ -47,7 +47,7 @@ class SetNodeTests: XCTestCase {
 
     XCTAssertEqual(node.variableName, "value")
     switch node.content {
-    case .value:
+    case .reference:
       break
     default:
       XCTFail("Unexpected node content")
@@ -84,7 +84,7 @@ class SetNodeTests: XCTestCase {
     }
 
     do {
-      let node = SetNode(variableName: "value", content: .value(Variable("test")))
+      let node = SetNode(variableName: "value", content: .reference(to: Variable("test")))
       let context = Context(dictionary: [:])
       let output = try node.render(context)
       XCTAssertEqual(output, "")
@@ -120,14 +120,14 @@ class SetNodeTests: XCTestCase {
     XCTAssertNil(context["c"])
 
     // alias a into c
-    node = SetNode(variableName: "c", content: .value(Variable("a")))
+    node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hi")
     XCTAssertEqual(context["b"] as? String, "world")
     XCTAssertEqual(context["c"] as? String, "hi")
 
     // alias non-existing into c
-    node = SetNode(variableName: "c", content: .value(Variable("foo")))
+    node = SetNode(variableName: "c", content: .reference(to: Variable("foo")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hi")
     XCTAssertEqual(context["b"] as? String, "world")
@@ -156,14 +156,14 @@ class SetNodeTests: XCTestCase {
     XCTAssertEqual(context["c"] as? Int, 3)
 
     // alias a into c
-    node = SetNode(variableName: "c", content: .value(Variable("a")))
+    node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hello")
     XCTAssertEqual(context["b"] as? String, "world")
     XCTAssertEqual(context["c"] as? String, "hello")
 
     // alias non-existing into c
-    node = SetNode(variableName: "c", content: .value(Variable("foo")))
+    node = SetNode(variableName: "c", content: .reference(to: Variable("foo")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hello")
     XCTAssertEqual(context["b"] as? String, "world")
@@ -217,7 +217,7 @@ class SetNodeTests: XCTestCase {
       XCTAssertNil(context["c"])
 
       // alias a into c
-      node = SetNode(variableName: "c", content: .value(Variable("a")))
+      node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
       _ = try node.render(context)
       XCTAssertEqual(context["a"] as? String, "hello")
       XCTAssertEqual(context["b"] as? Int, 2)
@@ -243,7 +243,7 @@ class SetNodeTests: XCTestCase {
     XCTAssertNil(context["b"])
 
     // set b
-    node = SetNode(variableName: "b", content: .value(Variable("items")))
+    node = SetNode(variableName: "b", content: .reference(to: Variable("items")))
     _ = try node.render(context)
     XCTAssertEqual(context["b"] as? [Int], [1, 3, 7])
   }

--- a/Tests/StencilSwiftKitTests/SetNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/SetNodeTests.swift
@@ -247,4 +247,15 @@ class SetNodeTests: XCTestCase {
     _ = try node.render(context)
     XCTAssertEqual(context["b"] as? [Int], [1, 3, 7])
   }
+
+  func testSetWithFilterExpressionParameter() throws {
+    let context = Context(dictionary: ["greet": "hello"])
+
+    let parser = TokenParser(tokens: [], environment: stencilSwiftEnvironment())
+    let argument = try FilterExpression(token: "greet|uppercase", parser: parser)
+    let node = SetNode(variableName: "a", content: .reference(to: argument))
+
+    _ = try node.render(context)
+    XCTAssertEqual(context["a"] as? String, "HELLO")
+  }
 }


### PR DESCRIPTION
Refs https://github.com/SwiftGen/SwiftGen/pull/379#issuecomment-388035669.

This feature adds a variation of the `set` tag to directly set the value of a variable to the contents of another expression, without rendering it down to a `String` (like the current `set` does).

Users will be able to use the `set` tag in 2 ways:
- `{% set myVar %}...{% endset %}` to render and store everything between the start and end tag into the variable.
- `{% set myVar someOtherVar.prop1.prop2 #}` to evaluate and store an expression's result into the variable.

This is particularly useful if the expression is a complex object such as an `Array` or a `Dictionary`.