### PR TITLE
SwiftLint 0.27

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,13 +1,16 @@
 opt_in_rules:
+ - anyobject_protocol
  - array_init
  - attributes
  - closure_end_indentation
  - closure_spacing
  - contains_over_first_not_nil
+ - convenience_type
  - discouraged_optional_boolean
  - discouraged_optional_collection
  - empty_count
  - empty_string
+ - fallthrough
  - fatal_error_message
  - first_where
  - force_unwrapping
@@ -15,8 +18,13 @@ opt_in_rules:
  - implicitly_unwrapped_optional
  - joined_default_parameter
  - literal_expression_end_indentation
+ - lower_acl_than_parent
+ - modifier_order
  - multiline_arguments
+ - multiline_function_chains
  - multiline_parameters
+ - number_separator
+ - object_literal
  - operator_usage_whitespace
  - overridden_super_call
  - override_in_extension
@@ -27,6 +35,7 @@ opt_in_rules:
  - sorted_first_last
  - sorted_imports
  - trailing_closure
+ - unavailable_function
  - unneeded_parentheses_in_closure_argument
  - vertical_parameter_alignment_on_call
  - yoda_condition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 * Updated to latest Xcode (9.3.0).  
   [David Jennes](https://github.com/djbe) 
   [#86](https://github.com/SwiftGen/StencilSwiftKit/pull/86)
+* Update to SwiftLint 0.27 and enable some extra SwiftLint rules.  
+  [David Jennes](https://github.com/djbe) 
+  [#96](https://github.com/SwiftGen/StencilSwiftKit/pull/96)
 
 ## 2.5.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - PathKit (~> 0.8.0)
   - StencilSwiftKit (2.5.0):
     - Stencil (~> 0.12)
-  - SwiftLint (0.25.1)
+  - SwiftLint (0.27.0)
 
 DEPENDENCIES:
   - StencilSwiftKit (from `.`)
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   PathKit: dcab05d701474011aae0e40cf892298a831f63d6
   Stencil: c324035607f483153c780fb42367d284cadd30a6
   StencilSwiftKit: 80a778f61bb742fd7714a5f9f3c2249d2eafa594
-  SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
 PODFILE CHECKSUM: 0bd9ec310bace9d5b62e785ea1fb74547c15074d
 

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -4,7 +4,7 @@ PODS:
     - PathKit (~> 0.8.0)
   - StencilSwiftKit (2.5.0):
     - Stencil (~> 0.12)
-  - SwiftLint (0.25.1)
+  - SwiftLint (0.27.0)
 
 DEPENDENCIES:
   - StencilSwiftKit (from `.`)
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   PathKit: dcab05d701474011aae0e40cf892298a831f63d6
   Stencil: c324035607f483153c780fb42367d284cadd30a6
   StencilSwiftKit: 80a778f61bb742fd7714a5f9f3c2249d2eafa594
-  SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
 PODFILE CHECKSUM: 0bd9ec310bace9d5b62e785ea1fb74547c15074d
 

--- a/Sources/SetNode.swift
+++ b/Sources/SetNode.swift
@@ -9,7 +9,7 @@ import Stencil
 class SetNode: NodeType {
   enum Content {
     case nodes([NodeType])
-    case reference(to: Resolvable)
+    case reference(resolvable: Resolvable)
   }
 
   let variableName: String
@@ -29,7 +29,7 @@ class SetNode: NodeType {
     if components.count == 3 {
       // we have a value expression, no nodes
       let resolvable = try parser.compileResolvable(components[2], containedIn: token)
-      return SetNode(variableName: variable, content: .reference(to: resolvable))
+      return SetNode(variableName: variable, content: .reference(resolvable: resolvable))
     } else {
       // no value expression, parse until an `endset` node
       let setNodes = try parser.parse(until(["endset"]))

--- a/Sources/StencilSwiftTemplate.swift
+++ b/Sources/StencilSwiftTemplate.swift
@@ -21,7 +21,7 @@ open class StencilSwiftTemplate: Template {
   }
 
   // swiftlint:disable:next discouraged_optional_collection
-  open override func render(_ dictionary: [String: Any]? = nil) throws -> String {
+  override open func render(_ dictionary: [String: Any]? = nil) throws -> String {
     return try removeExtraLines(from: super.render(dictionary))
   }
 

--- a/Tests/StencilSwiftKitTests/SetNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/SetNodeTests.swift
@@ -105,7 +105,7 @@ class SetNodeTests: XCTestCase {
     }
 
     do {
-      let node = SetNode(variableName: "value", content: .reference(to: Variable("test")))
+      let node = SetNode(variableName: "value", content: .reference(resolvable: Variable("test")))
       let context = Context(dictionary: [:])
       let output = try node.render(context)
       XCTAssertEqual(output, "")
@@ -141,14 +141,14 @@ class SetNodeTests: XCTestCase {
     XCTAssertNil(context["c"])
 
     // alias a into c
-    node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
+    node = SetNode(variableName: "c", content: .reference(resolvable: Variable("a")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hi")
     XCTAssertEqual(context["b"] as? String, "world")
     XCTAssertEqual(context["c"] as? String, "hi")
 
     // alias non-existing into c
-    node = SetNode(variableName: "c", content: .reference(to: Variable("foo")))
+    node = SetNode(variableName: "c", content: .reference(resolvable: Variable("foo")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hi")
     XCTAssertEqual(context["b"] as? String, "world")
@@ -177,14 +177,14 @@ class SetNodeTests: XCTestCase {
     XCTAssertEqual(context["c"] as? Int, 3)
 
     // alias a into c
-    node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
+    node = SetNode(variableName: "c", content: .reference(resolvable: Variable("a")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hello")
     XCTAssertEqual(context["b"] as? String, "world")
     XCTAssertEqual(context["c"] as? String, "hello")
 
     // alias non-existing into c
-    node = SetNode(variableName: "c", content: .reference(to: Variable("foo")))
+    node = SetNode(variableName: "c", content: .reference(resolvable: Variable("foo")))
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "hello")
     XCTAssertEqual(context["b"] as? String, "world")
@@ -238,7 +238,7 @@ class SetNodeTests: XCTestCase {
       XCTAssertNil(context["c"])
 
       // alias a into c
-      node = SetNode(variableName: "c", content: .reference(to: Variable("a")))
+      node = SetNode(variableName: "c", content: .reference(resolvable: Variable("a")))
       _ = try node.render(context)
       XCTAssertEqual(context["a"] as? String, "hello")
       XCTAssertEqual(context["b"] as? Int, 2)
@@ -264,7 +264,7 @@ class SetNodeTests: XCTestCase {
     XCTAssertNil(context["b"])
 
     // set b
-    node = SetNode(variableName: "b", content: .reference(to: Variable("items")))
+    node = SetNode(variableName: "b", content: .reference(resolvable: Variable("items")))
     _ = try node.render(context)
     XCTAssertEqual(context["b"] as? [Int], [1, 3, 7])
   }
@@ -274,7 +274,7 @@ class SetNodeTests: XCTestCase {
 
     let parser = TokenParser(tokens: [], environment: stencilSwiftEnvironment())
     let argument = try FilterExpression(token: "greet|uppercase", parser: parser)
-    let node = SetNode(variableName: "a", content: .reference(to: argument))
+    let node = SetNode(variableName: "a", content: .reference(resolvable: argument))
 
     _ = try node.render(context)
     XCTAssertEqual(context["a"] as? String, "HELLO")

--- a/Tests/StencilSwiftKitTests/StringFiltersTests.swift
+++ b/Tests/StencilSwiftKitTests/StringFiltersTests.swift
@@ -29,7 +29,7 @@ final class StringFiltersTests: XCTestCase {
       return stringRepresentation.hashValue
     }
 
-    public static func == (lhs: Input, rhs: Input) -> Bool {
+    static func == (lhs: Input, rhs: Input) -> Bool {
       return lhs.stringRepresentation == rhs.stringRepresentation
     }
   }

--- a/Tests/StencilSwiftKitTests/TestsHelper.swift
+++ b/Tests/StencilSwiftKitTests/TestsHelper.swift
@@ -18,7 +18,7 @@ private let koCode = (num: colorCode("fg127,127,127") + colorCode("bg127,0,0"),
 
 func diff(_ result: String, _ expected: String) -> String? {
   guard result != expected else { return nil }
-  var firstDiff: Int? = nil
+  var firstDiff: Int?
   let newlines = CharacterSet.newlines
   let lhsLines = result.components(separatedBy: newlines)
   let rhsLines = expected.components(separatedBy: newlines)


### PR DESCRIPTION
Based on #95, so merge that first. ✅ 

This simply updates SwiftLint and fixes some warnings that are triggered in combination with Xcode 10. I've also enabled some more rules while I was it, nothing with much impact, but good to have.

I'd love to enable [function_default_parameter_at_end](https://github.com/realm/SwiftLint/blob/master/Rules.md#function-default-parameter-at-end), but that isn't an option with https://github.com/SwiftGen/StencilSwiftKit/blob/master/Sources/Filters.swift#L92. It'd be a breaking change to move those parameters, and we can't add an alias (while deprecating the current signature) because it confuses Swift.