### PR TITLE
Fix `swiftIdentifier` crash with empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* `swiftIdentifier`: fix crash on empty string.  
+  [David Jennes](https://github.com/djbe)
+  [#105](https://github.com/SwiftGen/StencilSwiftKit/pull/105)
 
 ### Internal Changes
 

--- a/Sources/StencilSwiftKit/SwiftIdentifier.swift
+++ b/Sources/StencilSwiftKit/SwiftIdentifier.swift
@@ -114,10 +114,9 @@ enum SwiftIdentifier {
   static func prefixWithUnderscoreIfNeeded(string: String,
                                            forbiddenChars exceptions: String = "") -> String {
 
-    let (head, _) = identifierCharacterSets(exceptions: exceptions)
+    guard let firstChar = string.unicodeScalars.first else { return "" }
 
-    let chars = string.unicodeScalars
-    let firstChar = chars[chars.startIndex]
+    let (head, _) = identifierCharacterSets(exceptions: exceptions)
     let prefix = !head.longCharacterIsMember(firstChar.value) ? "_" : ""
 
     return prefix + string

--- a/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
+++ b/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
@@ -47,6 +47,10 @@ class SwiftIdentifierTests: XCTestCase {
       SwiftIdentifier.identifier(from: "hello$world^this*contains%a=lot@of<forbidden>chars!does#it/still:work.anyway?"),
       "HelloWorldThisContainsALotOfForbiddenCharsDoesItStillWorkAnyway")
   }
+
+  func testEmptyString() {
+    XCTAssertEqual(SwiftIdentifier.identifier(from: ""), "")
+  }
 }
 
 extension SwiftIdentifierTests {


### PR DESCRIPTION
Fixes https://github.com/SwiftGen/SwiftGen/issues/528.