### PR TITLE
Parameters: fix flatten function for `false` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* `Parameters`: ensure the `flatten` function correctly handles a flag with a `false` value.  
+  [David Jennes](https://github.com/djbe)
+  [#108](https://github.com/SwiftGen/StencilSwiftKit/pull/108)
 
 ### Internal Changes
 

--- a/Sources/StencilSwiftKit/Parameters.swift
+++ b/Sources/StencilSwiftKit/Parameters.swift
@@ -147,7 +147,7 @@ public enum Parameters {
     switch object {
     case is String, is Int, is Double:
       values.append("\(keyPrefix)=\(object)")
-    case is Bool:
+    case let bool as Bool where bool:
       values.append(keyPrefix)
     case let dict as [String: Any]:
       for (key, value) in dict {

--- a/Tests/StencilSwiftKitTests/ParametersTests.swift
+++ b/Tests/StencilSwiftKitTests/ParametersTests.swift
@@ -93,6 +93,20 @@ class ParametersTests: XCTestCase {
                    "The order of arrays are properly preserved when flattened")
   }
 
+  func testFlattenBool() {
+    let trueFlag = Parameters.flatten(dictionary: ["test": true])
+    XCTAssertEqual(trueFlag, ["test"], "True flag is flattened to a param without value")
+
+    let falseFlag = Parameters.flatten(dictionary: ["test": false])
+    XCTAssertEqual(falseFlag, [], "False flag is flattened to nothing")
+
+    let stringFlag = Parameters.flatten(dictionary: ["test": "a"])
+    XCTAssertEqual(stringFlag, ["test=a"], "Non-boolean flag is flattened to a parameter with value")
+
+    let falseStringFlag = Parameters.flatten(dictionary: ["test": "false"])
+    XCTAssertEqual(falseStringFlag, ["test=false"], "Non-boolean flag is flattened to a parameter with value")
+  }
+
   func testParseInvalidSyntax() {
     // invalid character
     do {

--- a/Tests/StencilSwiftKitTests/XCTestManifests.swift
+++ b/Tests/StencilSwiftKitTests/XCTestManifests.swift
@@ -51,6 +51,7 @@ extension ParametersTests {
     static let __allTests = [
         ("testBasic", testBasic),
         ("testDeepStructured", testDeepStructured),
+        ("testFlattenBool", testFlattenBool),
         ("testParseInvalidKey", testParseInvalidKey),
         ("testParseInvalidStructure", testParseInvalidStructure),
         ("testParseInvalidSyntax", testParseInvalidSyntax),
@@ -153,6 +154,7 @@ extension SwiftIdentifierTests {
         ("testBasicStringWithForbiddenCharsAndUnderscores", testBasicStringWithForbiddenCharsAndUnderscores),
         ("testEmojis", testEmojis),
         ("testEmojis2", testEmojis2),
+        ("testEmptyString", testEmptyString),
         ("testForbiddenChars", testForbiddenChars),
         ("testKeepUppercaseAcronyms", testKeepUppercaseAcronyms),
         ("testNumbersFirst", testNumbersFirst),


### PR DESCRIPTION
Fixes https://github.com/SwiftGen/SwiftGen/issues/434.