### PR TITLE
Add a new filter to output a unicode codepoint

### DIFF
--- a/Sources/StencilSwiftKit/Environment.swift
+++ b/Sources/StencilSwiftKit/Environment.swift
@@ -42,6 +42,7 @@ public extension Extension {
     registerFilter("snakeToCamelCase", filter: Filters.Strings.snakeToCamelCase)
     registerFilter("swiftIdentifier", filter: Filters.Strings.swiftIdentifier)
     registerFilter("titlecase", filter: Filters.Strings.upperFirstLetter)
+    registerFilter("unicodeCase", filter: Filters.Strings.unicodeCase)
     registerFilter("upperFirstLetter", filter: Filters.Strings.upperFirstLetter)
     registerFilter("contains", filter: Filters.Strings.contains)
     registerFilter("hasPrefix", filter: Filters.Strings.hasPrefix)

--- a/Sources/StencilSwiftKit/Filters+Strings.swift
+++ b/Sources/StencilSwiftKit/Filters+Strings.swift
@@ -179,6 +179,14 @@ extension Filters.Strings {
     return result
   }
 
+  static func unicodeCase(value: Any?) throws -> Any? {
+    guard let string = value as? String else { throw Filters.Error.invalidInputType }
+    let escapingCharacterSet = CharacterSet(charactersIn: "\\")
+    let unicode = string.trimmingCharacters(in: escapingCharacterSet)
+
+    return "\\u{" + unicode + "}"
+  }
+
   // MARK: Private
 
   private static func containsAnyLowercasedChar(_ string: String) throws -> Bool {


### PR DESCRIPTION
Adds a new filter, `unicodeCase`, which outputs a Unicode code point to a formatted string.

Related PR: https://github.com/SwiftGen/SwiftGen/pull/638