### PR TITLE
Adds Support for Swift 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#116](https://github.com/SwiftGen/StencilSwiftKit/pull/116)
 
+## 2.8.0
+
+* Updated Stencil to the latest version (0.13.1).
+  [Hector Matos](https://github.com/hectormatos2011)
+  [#122](https://github.com/SwiftGen/StencilSwiftKit/pull/122)
+
 ## 2.7.2
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ _None_
 
 ## 2.8.0
 
-* Updated Stencil to the latest version (0.13.1).
+* Updated Stencil to the latest version (0.13.1).  
   [Hector Matos](https://github.com/hectormatos2011)
   [#122](https://github.com/SwiftGen/StencilSwiftKit/pull/122)
 

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+  name: "StencilSwiftKit",
+  products: [
+      .library(name: "StencilSwiftKit", targets: ["StencilSwiftKit"])
+  ],
+  dependencies: [
+      .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMinor(from: "0.13.1"))
+  ],
+  targets: [
+    .target(
+      name: "StencilSwiftKit",
+      dependencies: [
+        "Stencil"
+      ]
+    ),
+    .testTarget(
+      name: "StencilSwiftKitTests",
+      dependencies: [
+        "StencilSwiftKit"
+      ]
+    )
+  ],
+  swiftLanguageVersions: [.v4_2, .v5.0]
+)

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -23,5 +23,5 @@ let package = Package(
       ]
     )
   ],
-  swiftLanguageVersions: [.v4_2, .v5.0]
+  swiftLanguageVersions: [.v4, .v4_2, .v5]
 )

--- a/StencilSwiftKit.podspec
+++ b/StencilSwiftKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'StencilSwiftKit'
-  s.version      = '2.7.2'
+  s.version      = '2.7.3'
   s.summary      = 'Stencil additions dedicated for Swift code generation'
 
   s.description  = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/aligatr'
 
   s.platform = :osx, '10.9'
-  s.swift_version = '4.2'
+  s.swift_version = '4.2', '5.0'
   s.cocoapods_version = '>= 1.4.0'
 
   s.source       = {
@@ -27,6 +27,6 @@ Pod::Spec.new do |s|
   }
   s.source_files = 'Sources/**/*.swift'
 
-  s.dependency 'Stencil', '~> 0.13.1'
+  s.dependency 'Stencil', '~> 0.13.2'
   s.framework = 'Foundation'
 end


### PR DESCRIPTION
Hello!

# Internal Change
It's been bothering me that when I use Swift 5 with StencilSwiftKit, a few warnings pop up due to outdated usages of older Swift APIs. By updating this library to support Swift 5, those warnings will go away. I also fixed the warning for redundant usages of `public` within `public` extensions.

Since [Stencil](https://github.com/stencilproject/Stencil) no longer supports versions of [Swift earlier than 4.1](https://github.com/stencilproject/Stencil/pull/228), I updated the library to do the same by dropping support as well.