### PR TITLE
Add Swift 5.2 support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -23,9 +23,9 @@
         "package": "Stencil",
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
-          "branch": null,
-          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
-          "version": "0.13.1"
+          "branch": "master",
+          "revision": "9c3468e300ba75ede0d7eb4c495897e0ac3591c3",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -7,7 +7,7 @@ let package = Package(
       .library(name: "StencilSwiftKit", targets: ["StencilSwiftKit"])
   ],
   dependencies: [
-      .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMinor(from: "0.13.0"))
+      .package(url: "https://github.com/stencilproject/Stencil.git", .branch("master"))
   ],
   targets: [
     .target(
@@ -22,6 +22,5 @@ let package = Package(
         "StencilSwiftKit"
       ]
     )
-  ],
-  swiftLanguageVersions: [4]
+  ]
 )

--- a/Sources/StencilSwiftKit/CallMacroNodes.swift
+++ b/Sources/StencilSwiftKit/CallMacroNodes.swift
@@ -41,7 +41,7 @@ class MacroNode: NodeType {
   let token: Token?
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-    let components = token.components()
+    let components = token.components
     guard components.count >= 2 else {
       throw TemplateSyntaxError("'macro' tag takes at least one argument, the name of the variable to set.")
     }
@@ -76,7 +76,7 @@ class CallNode: NodeType {
   let token: Token?
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-    let components = token.components()
+    let components = token.components
     guard components.count >= 2 else {
       throw TemplateSyntaxError("'call' tag takes at least one argument, the name of the block to call.")
     }

--- a/Sources/StencilSwiftKit/Environment.swift
+++ b/Sources/StencilSwiftKit/Environment.swift
@@ -7,7 +7,7 @@
 import Stencil
 
 public extension Extension {
-  public func registerStencilSwiftExtensions() {
+  func registerStencilSwiftExtensions() {
     registerTags()
     registerStringsFilters()
     registerNumbersFilters()

--- a/Sources/StencilSwiftKit/Filters+Strings.swift
+++ b/Sources/StencilSwiftKit/Filters+Strings.swift
@@ -95,7 +95,7 @@ extension Filters.Strings {
     while idx < scalars.endIndex, let scalar = UnicodeScalar(scalars[idx].value), characterSet.contains(scalar) {
       idx = scalars.index(after: idx)
     }
-    if idx > scalars.index(after: start) && idx < scalars.endIndex,
+    if idx < scalars.endIndex, idx > scalars.index(after: start),
       let scalar = UnicodeScalar(scalars[idx].value),
       CharacterSet.lowercaseLetters.contains(scalar) {
       idx = scalars.index(before: idx)

--- a/Sources/StencilSwiftKit/MapNode.swift
+++ b/Sources/StencilSwiftKit/MapNode.swift
@@ -14,7 +14,7 @@ class MapNode: NodeType {
   let token: Token?
 
   class func parse(parser: TokenParser, token: Token) throws -> NodeType {
-    let components = token.components()
+    let components = token.components
 
     func hasToken(_ token: String, at index: Int) -> Bool {
       return components.indices ~= index + 1 && components[index] == token

--- a/Sources/StencilSwiftKit/SetNode.swift
+++ b/Sources/StencilSwiftKit/SetNode.swift
@@ -17,7 +17,7 @@ class SetNode: NodeType {
   let token: Token?
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-    let components = token.components()
+    let components = token.components
     guard components.count <= 3 else {
       throw TemplateSyntaxError(
         """

--- a/Tests/StencilSwiftKitTests/CallNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/CallNodeTests.swift
@@ -79,7 +79,7 @@ class CallNodeTests: XCTestCase {
   }
 
   func testRenderFail() {
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     let node = CallNode(variable: Variable("myFunc"), arguments: [])
 
     XCTAssertThrowsError(try node.render(context))

--- a/Tests/StencilSwiftKitTests/MacroNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/MacroNodeTests.swift
@@ -74,7 +74,7 @@ class MacroNodeTests: XCTestCase {
 
   func testRender() throws {
     let node = MacroNode(variableName: "myFunc", parameters: [], nodes: [TextNode(text: "hello")])
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     let output = try node.render(context)
 
     XCTAssertEqual(output, "")
@@ -82,7 +82,7 @@ class MacroNodeTests: XCTestCase {
 
   func testRenderWithParameters() throws {
     let node = MacroNode(variableName: "myFunc", parameters: ["a", "b", "c"], nodes: [TextNode(text: "hello")])
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     let output = try node.render(context)
 
     XCTAssertEqual(output, "")
@@ -90,7 +90,7 @@ class MacroNodeTests: XCTestCase {
 
   func testContextModification() throws {
     let node = MacroNode(variableName: "myFunc", parameters: [], nodes: [TextNode(text: "hello")])
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     _ = try node.render(context)
 
     guard let block = context["myFunc"] as? CallableBlock else {
@@ -104,7 +104,7 @@ class MacroNodeTests: XCTestCase {
 
   func testContextModificationWithParameters() throws {
     let node = MacroNode(variableName: "myFunc", parameters: ["a", "b", "c"], nodes: [TextNode(text: "hello")])
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     _ = try node.render(context)
 
     guard let block = context["myFunc"] as? CallableBlock else {
@@ -130,8 +130,7 @@ class MacroNodeTests: XCTestCase {
   func testCallableBlockWithFilterExpressionParameter() throws {
     let block = CallableBlock(parameters: ["greeting"], nodes: [])
 
-    let parser = TokenParser(tokens: [], environment: stencilSwiftEnvironment())
-    let arguments = try [FilterExpression(token: "greet|uppercase", parser: parser)]
+    let arguments = try [FilterExpression(token: "greet|uppercase", environment: stencilSwiftEnvironment())]
     let context = Context(dictionary: ["greet": "hello"])
 
     let result = try block.context(context, arguments: arguments, variable: Variable("myFunc"))

--- a/Tests/StencilSwiftKitTests/SetNodeTests.swift
+++ b/Tests/StencilSwiftKitTests/SetNodeTests.swift
@@ -99,14 +99,14 @@ class SetNodeTests: XCTestCase {
   func testRender() throws {
     do {
       let node = SetNode(variableName: "value", content: .nodes([TextNode(text: "true")]))
-      let context = Context(dictionary: [:])
+      let context = Context(dictionary: ["": ""])
       let output = try node.render(context)
       XCTAssertEqual(output, "")
     }
 
     do {
       let node = SetNode(variableName: "value", content: .reference(resolvable: Variable("test")))
-      let context = Context(dictionary: [:])
+      let context = Context(dictionary: ["": ""])
       let output = try node.render(context)
       XCTAssertEqual(output, "")
     }
@@ -114,7 +114,7 @@ class SetNodeTests: XCTestCase {
 
   func testContextModification() throws {
     // start empty
-    let context = Context(dictionary: [:])
+    let context = Context(dictionary: ["": ""])
     XCTAssertNil(context["a"])
     XCTAssertNil(context["b"])
     XCTAssertNil(context["c"])
@@ -272,8 +272,7 @@ class SetNodeTests: XCTestCase {
   func testSetWithFilterExpressionParameter() throws {
     let context = Context(dictionary: ["greet": "hello"])
 
-    let parser = TokenParser(tokens: [], environment: stencilSwiftEnvironment())
-    let argument = try FilterExpression(token: "greet|uppercase", parser: parser)
+    let argument = try FilterExpression(token: "greet|uppercase", environment: stencilSwiftEnvironment())
     let node = SetNode(variableName: "a", content: .reference(resolvable: argument))
 
     _ = try node.render(context)


### PR DESCRIPTION
Change Log

- Fix a crash due to order of conditions
- Change dependency of the Stencil package to the master branch; this is not optimal, but Stencil didn't have a release for a long time and Swift 5.2. support is only available on the master branch
- Adapt code to Swift 5.2/Stencil master (API changes)