### PR TITLE
CHANGELOG: Add missing bug fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fix crash with the `lowerFirstWord` filter when running on empty strings.  
+  [@fortmarek](https://github.com/fortmarek)
+  [#127](https://github.com/SwiftGen/StencilSwiftKit/pull/127)
 
 ### Internal Changes
 


### PR DESCRIPTION
I encountered the issue just today that SwiftGen crashed with fatal error when parsing a `.strings` file containing some `""` strings in it. I then went to debug it and found it was because our `lowerFirstWord` filter was crashing on empty strings (`startIndex == endIndex` in those cases, which we didn't guard about as we used `<` not `<=` as a guard)

But then when I looked at the code (`Filters+Strings.swift`) I saw that it was [already fixed in `stable` by @fortmarek when he was working on #127](https://github.com/SwiftGen/StencilSwiftKit/pull/127/files#diff-5190d285cdf82bd5be948bacfbf1ca48c5edabbc9d1a064f8f67464f86bc1263R91) – we just didn't add the entry for it given the main focus of #127 was on something else (for which it does have a CHANGELOG entry). But since #127 fixed 2 issues in one, we should also mention the fix there.