### PR TITLE
Ensure GitHub status checks always work

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -3,13 +3,7 @@ name: Cocoapods
 on:
   push:
     branches: stable
-    paths:
-      - '.github/workflows/cocoapods.yml'
-      - '*.podspec'
   pull_request:
-    paths:
-      - '.github/workflows/cocoapods.yml'
-      - '*.podspec'
 
 jobs:
   lint:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -3,15 +3,7 @@ name: SwiftLint
 on:
   push:
     branches: stable
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
   pull_request:
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
 
 jobs:
   lint:

--- a/.github/workflows/test-spm.yml
+++ b/.github/workflows/test-spm.yml
@@ -3,13 +3,7 @@ name: Test SPM
 on:
   push:
     branches: stable
-    paths:
-      - '.github/workflows/test-spm.yml'
-      - '**/*.swift'
   pull_request:
-    paths:
-      - '.github/workflows/test-spm.yml'
-      - '**/*.swift'
 
 jobs:
   linux:

--- a/.github/workflows/test-xcode.yml
+++ b/.github/workflows/test-xcode.yml
@@ -3,13 +3,7 @@ name: Test Xcode
 on:
   push:
     branches: stable
-    paths:
-      - '.github/workflows/test-xcode.yml'
-      - '**/*.swift'
   pull_request:
-    paths:
-      - '.github/workflows/test-xcode.yml'
-      - '**/*.swift'
 
 jobs:
   test:


### PR DESCRIPTION
If we define paths for actions, then sometimes some actions won't be run
--> status check won't be set
--> can't merge PR

We'll have to remove these for now, as long as GitHub doesn't support ignoring required checkes if they're ignored by paths.