### PR TITLE
Better environment creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### New Features
 
-_None_
+* `stencilSwiftEnvironment` now accepts a list of paths (for the template loader) & extensions.  
+  [David Jennes](https://github.com/djbe)
+  [#154](https://github.com/SwiftGen/StencilSwiftKit/pull/154)
 
 ### Bug Fixes
 

--- a/Sources/StencilSwiftKit/Environment.swift
+++ b/Sources/StencilSwiftKit/Environment.swift
@@ -4,6 +4,7 @@
 // MIT Licence
 //
 
+import PathKit
 import Stencil
 
 public extension Extension {
@@ -59,10 +60,14 @@ private extension Extension {
 
 /// Creates an Environment for Stencil to load & render templates
 ///
+/// - Parameters:
+///   - templatePaths: Paths where Stencil can search for templates, used for example for `include` tags
+///   - extensions: Additional extensions with filters/tags/… you want to provide to Stencil
 /// - Returns: A fully configured `Environment`
-public func stencilSwiftEnvironment() -> Environment {
+public func stencilSwiftEnvironment(templatePaths: [Path] = [], extensions: [Extension] = []) -> Environment {
+  let loader = FileSystemLoader(paths: templatePaths)
   let ext = Extension()
   ext.registerStencilSwiftExtensions()
 
-  return Environment(extensions: [ext], templateClass: StencilSwiftTemplate.self)
+  return Environment(loader: loader, extensions: extensions + [ext], templateClass: StencilSwiftTemplate.self)
 }


### PR DESCRIPTION
Improve our `stencilSwiftEnvironment` to accept a list of paths & extensions:
- List of paths allows us to configure a loader, so that tags like `include` can work correctly
- List of extensions, so that users may provide their own set of Stencil extensions