### PR TITLE
Add `swiftIdentifier` mode `valid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * Added an `import` tag for reusing macro's in multiple templates from a common imported file.  
   [David Jennes](https://github.com/djbe)
   [#111](https://github.com/SwiftGen/StencilSwiftKit/pull/111)
+* The `swiftIdentifier` now supports a `valid` mode, where it will do the bare minimum to get a valid identifier. I.e. it will not change the case of characters at all (compared to `normal` mode).  
+  [David Jennes](https://github.com/djbe)
+  [#160](https://github.com/SwiftGen/StencilSwiftKit/pull/160)
 
 ### Bug Fixes
 

--- a/Documentation/filters-strings.md
+++ b/Documentation/filters-strings.md
@@ -146,18 +146,19 @@ https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift
 
 This filter has a couple of modes that you can specify using an optional mode argument:
 
-- **normal** (default): apply the steps mentioned above (uppercase first, prefix if needed, replace invalid characters with `_`)
+- **valid**: Only do the bare minimum for a valid identifier, i.e. the steps mentioned above **except** uppercasing characters.
+- **normal** (default): apply the steps mentioned above (uppercase first, prefix if needed, replace invalid characters with `_`).
 - **pretty**: Same as normal, but afterwards it will apply the `snakeToCamelCase` filter, and other manipulations, for a prettier (but still valid) identifier.
 
-| Input                  | Output (`normal`)         | Output (`pretty`)      |
-|------------------------|---------------------------|------------------------|
-| `hello`                | `Hello`                   | `Hello`                |
-| `42hello`              | `_42hello`                | `_42hello`             |
-| `some$URL`             | `Some_URL`                | `SomeURL`              |
-| `25 Ultra Light`       | `_25_Ultra_Light`         | `_25UltraLight`        |
-| `26_extra_ultra_light` | `_26_extra_ultra_light`   | `_26ExtraUltraLight`   |
-| `apples.count`         | `Apples_Count`            | `ApplesCount`          |
-| `foo_bar.baz.qux-yay`  | `Foo_bar_Baz_Qux_Yay`     | `FooBarBazQuxYay`      |
+| Input                  | Output (`valid`)        | Output (`normal`)       | Output (`pretty`)    |
+|------------------------|-------------------------|-------------------------|----------------------|
+| `hello`                | `hello`                 | `Hello`                 | `Hello`              |
+| `42hello`              | `_42hello`              | `_42hello`              | `_42hello`           |
+| `some$URL`             | `some_URL`              | `Some_URL`              | `SomeURL`            |
+| `25 Ultra Light`       | `_25_Ultra_Light`       | `_25_Ultra_Light`       | `_25UltraLight`      |
+| `26_extra_ultra_light` | `_26_extra_ultra_light` | `_26_extra_ultra_light` | `_26ExtraUltraLight` |
+| `apples.count`         | `apples_count`          | `Apples_Count`          | `ApplesCount`        |
+| `foo_bar.baz.qux-yay`  | `foo_bar_baz_qux_yay`   | `Foo_bar_Baz_Qux_Yay`   | `FooBarBazQuxYay`    |
 
 
 ## Filter: `titlecase`

--- a/Sources/StencilSwiftKit/Filters+Strings.swift
+++ b/Sources/StencilSwiftKit/Filters+Strings.swift
@@ -28,7 +28,7 @@ public enum ReplaceModes: String {
 
 /// Possible modes for swiftIdentifier filter
 public enum SwiftIdentifierModes: String {
-  case normal, pretty
+  case valid, normal, pretty
 }
 
 // MARK: - String Filters: Boolean filters
@@ -271,10 +271,10 @@ public extension Filters.Strings {
   }
 
   /// Converts an arbitrary string to a valid swift identifier. Takes an optional Mode argument:
-  ///   - normal (default): uppercase the first character, prefix with an underscore if starting
-  ///     with a number, replace invalid characters by underscores
-  ///   - leading: same as the above, but apply the snaceToCamelCase filter first for a nicer
-  ///     identifier
+  ///   - valid: prefix with an underscore if starting with a number, replace invalid characters by underscores
+  ///   - normal (default): uppercase the first character, prefix with an underscore if starting with a number, replace
+  ///     invalid characters by underscores
+  ///   - leading: same as the above, but apply the snaceToCamelCase filter first for a nicer identifier
   ///
   /// - Parameters:
   ///   - value: the value to be processed
@@ -286,10 +286,12 @@ public extension Filters.Strings {
     let mode = try Filters.parseEnum(from: arguments, default: SwiftIdentifierModes.normal)
 
     switch mode {
+    case .valid:
+      return SwiftIdentifier.identifier(from: string, capitalizeComponents: false, replaceWithUnderscores: true)
     case .normal:
-      return SwiftIdentifier.identifier(from: string, replaceWithUnderscores: true)
+      return SwiftIdentifier.identifier(from: string, capitalizeComponents: true, replaceWithUnderscores: true)
     case .pretty:
-      string = SwiftIdentifier.identifier(from: string, replaceWithUnderscores: true)
+      string = SwiftIdentifier.identifier(from: string, capitalizeComponents: true, replaceWithUnderscores: true)
       string = try snakeToCamelCase(string, stripLeading: true)
       return SwiftIdentifier.prefixWithUnderscoreIfNeeded(string: string)
     }

--- a/Sources/StencilSwiftKit/SwiftIdentifier.swift
+++ b/Sources/StencilSwiftKit/SwiftIdentifier.swift
@@ -86,14 +86,18 @@ private extension CharacterSet {
 }
 
 enum SwiftIdentifier {
-  static func identifier(from string: String, replaceWithUnderscores underscores: Bool = false) -> String {
+  static func identifier(
+    from string: String,
+    capitalizeComponents: Bool = true,
+    replaceWithUnderscores underscores: Bool = false
+  ) -> String {
     let parts = string.components(separatedBy: CharacterSet.illegalIdentifierTail.inverted)
     let replacement = underscores ? "_" : ""
-    let mappedParts = parts.map { (string: String) -> String in
+    let mappedParts = !capitalizeComponents ? parts : parts.map { part in
       // Can't use capitalizedString here because it will lowercase all letters after the first
       // e.g. "SomeNiceIdentifier".capitalizedString will because "Someniceidentifier" which is not what we want
-      guard let first = string.unicodeScalars.first else { return string }
-      return String(first).uppercased() + String(string.unicodeScalars.dropFirst())
+      guard let first = part.unicodeScalars.first else { return part }
+      return String(first).uppercased() + String(part.unicodeScalars.dropFirst())
     }
 
     let result = mappedParts.joined(separator: replacement)

--- a/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
+++ b/Tests/StencilSwiftKitTests/SwiftIdentifierTests.swift
@@ -61,6 +61,29 @@ extension SwiftIdentifierTests {
     }
   }
 
+  func testSwiftIdentifier_WithValid() throws {
+    let expectations = [
+      "hello": "hello",
+      "42hello": "_42hello",
+      "some$URL": "some_URL",
+      "with space": "with_space",
+      "apples.count": "apples_count",
+      ".SFNSDisplay": "_SFNSDisplay",
+      "Show-NavCtrl": "Show_NavCtrl",
+      "HEADER_TITLE": "HEADER_TITLE",
+      "multiLine\nKey": "multiLine_Key",
+      "foo_bar.baz.qux-yay": "foo_bar_baz_qux_yay",
+      "25 Ultra Light": "_25_Ultra_Light",
+      "26_extra_ultra_light": "_26_extra_ultra_light",
+      "12 @ 34 % 56 + 78 Hello world": "_12___34___56___78_Hello_world"
+    ]
+
+    for (input, expected) in expectations {
+      let result = try Filters.Strings.swiftIdentifier(input, arguments: ["valid"]) as? String
+      XCTAssertEqual(result, expected)
+    }
+  }
+
   func testSwiftIdentifier_WithNormal() throws {
     let expectations = [
       "hello": "Hello",


### PR DESCRIPTION
Adds the mode discussed in #101 for minimal modification of values.