### PR TITLE
Fix version for Komondor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Pin Komondor to 1.1.3, to avoid issues with SPM for other packages depending on this package.  
+  [redryerye](https://github.com/redryerye)
+  [#162](https://github.com/SwiftGen/StencilSwiftKit/pull/162)
 
 ## 2.10.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "dedffeaf42a1b52bf072a9dc47afb35000a8b265",
-          "version": "1.1.4"
-        }
-      },
-      {
-        "package": "Logger",
-        "repositoryURL": "https://github.com/shibapm/Logger",
-        "state": {
-          "branch": null,
-          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
-          "version": "0.2.3"
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
         }
       },
       {
@@ -38,30 +29,12 @@
         }
       },
       {
-        "package": "Rocket",
-        "repositoryURL": "https://github.com/f-meloni/Rocket",
-        "state": {
-          "branch": null,
-          "revision": "9880a5beb7fcb9e61ddd5764edc1700b8c418deb",
-          "version": "1.2.1"
-        }
-      },
-      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
           "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
           "version": "2.3.0"
-        }
-      },
-      {
-        "package": "SourceKitten",
-        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-        "state": {
-          "branch": null,
-          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
-          "version": "0.32.0"
         }
       },
       {
@@ -80,78 +53,6 @@
           "branch": null,
           "revision": "8989f8a18998bd67b1727c2c0798b7c0436aa481",
           "version": "0.15.0"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
-        "state": {
-          "branch": null,
-          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-          "version": "0.50600.1"
-        }
-      },
-      {
-        "package": "SwiftFormat",
-        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat.git",
-        "state": {
-          "branch": null,
-          "revision": "665c3c58923ee8ac36d3e44b17dc185229cce301",
-          "version": "0.49.13"
-        }
-      },
-      {
-        "package": "SwiftLint",
-        "repositoryURL": "https://github.com/Realm/SwiftLint.git",
-        "state": {
-          "branch": null,
-          "revision": "22fb9eb9e55b8f5ad9b48fe6f15ea7daabaafae3",
-          "version": "0.48.0"
-        }
-      },
-      {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
-        "state": {
-          "branch": null,
-          "revision": "a6014fe94c3dbff0ad500e8da4f251a5d336530b",
-          "version": "5.1.0-beta.1"
-        }
-      },
-      {
-        "package": "SwiftyTextTable",
-        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-        "state": {
-          "branch": null,
-          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
-          "version": "6.0.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     .library(name: "StencilSwiftKit", targets: ["StencilSwiftKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/shibapm/Komondor.git", from: "1.1.3"),
+    .package(url: "https://github.com/shibapm/Komondor.git", .exact("1.1.3")),
     .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.15.0"))
   ],
   targets: [


### PR DESCRIPTION
[Komondor](https://github.com/shibapm/Komondor) had a release for [v.1.1.4](https://github.com/shibapm/Komondor/compare/1.1.3...1.1.4) where it added unnecessary dependencies that will only be used in Komondor's development process.
It would be great if we could minimize dependencies to avoid SPM conflicts by not updating Komondor to v1.1.4.

Right now, Sourcery as a SPM plugin is [facing a conflict](https://github.com/krzysztofzablocki/Sourcery/issues/1023#issuecomment-1180284670) because of this.